### PR TITLE
Fix include paths to glfw for RTC build

### DIFF
--- a/examples/imgui_impl_glfw.cpp
+++ b/examples/imgui_impl_glfw.cpp
@@ -36,11 +36,11 @@
 #include "imgui_impl_glfw.h"
 
 // GLFW
-#include <glfw/glfw3.h>
+#include <GLFW/glfw3.h>
 #ifdef _WIN32
 #undef APIENTRY
 #define GLFW_EXPOSE_NATIVE_WIN32
-#include <glfw/glfw3native.h>   // for glfwGetWin32Window
+#include <GLFW/glfw3native.h>   // for glfwGetWin32Window
 #endif
 #define GLFW_HAS_WINDOW_TOPMOST     (GLFW_VERSION_MAJOR * 1000 + GLFW_VERSION_MINOR * 100 >= 3200) // 3.2+ GLFW_FLOATING
 #define GLFW_HAS_WINDOW_HOVERED     (GLFW_VERSION_MAJOR * 1000 + GLFW_VERSION_MINOR * 100 >= 3300) // 3.3+ GLFW_HOVERED

--- a/imgui.lua
+++ b/imgui.lua
@@ -9,6 +9,7 @@ uuid "00273C6F-C6D6-456A-9DFC-B65011816616"
 includedirs {
   ".",
   _3RDPARTY_DIR,
+  _3RDPARTY_DIR .. "/glfw/include",
 }
 
 files {


### PR DESCRIPTION
* Revert an include path case change to be consistent with glfw source.
* Add the RTC 3rdparty glfw include path
