### PR TITLE
Enable Vulkan in Linux/Windows

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -140,12 +140,12 @@ void ImGui_ImplVulkanH_CreateWindowCommandBuffers(VkPhysicalDevice physical_devi
 
 // Vulkan prototypes for use with custom loaders
 // (see description of IMGUI_IMPL_VULKAN_NO_PROTOTYPES in imgui_impl_vulkan.h
-#if defined(VK_NO_PROTOTYPES) && !defined(VOLK_HEADER_VERSION)
+#if defined(VK_NO_PROTOTYPES) && !defined(RTC)
 static bool g_FunctionsLoaded = false;
 #else
 static bool g_FunctionsLoaded = true;
 #endif
-#if defined(VK_NO_PROTOTYPES) && !defined(VOLK_HEADER_VERSION)
+#if defined(VK_NO_PROTOTYPES) && !defined(RTC)
 #define IMGUI_VULKAN_FUNC_MAP(IMGUI_VULKAN_FUNC_MAP_MACRO) \
     IMGUI_VULKAN_FUNC_MAP_MACRO(vkAllocateCommandBuffers) \
     IMGUI_VULKAN_FUNC_MAP_MACRO(vkAllocateDescriptorSets) \
@@ -965,7 +965,7 @@ bool    ImGui_ImplVulkan_LoadFunctions(PFN_vkVoidFunction(*loader_func)(const ch
     // You can use the default Vulkan loader using:
     //      ImGui_ImplVulkan_LoadFunctions([](const char* function_name, void*) { return vkGetInstanceProcAddr(your_vk_isntance, function_name); });
     // But this would be equivalent to not setting VK_NO_PROTOTYPES.
-#if defined(VK_NO_PROTOTYPES) && !defined(VOLK_HEADER_VERSION)
+#if defined(VK_NO_PROTOTYPES) && !defined(RTC)
 #define IMGUI_VULKAN_FUNC_LOAD(func) \
     func = reinterpret_cast<decltype(func)>(loader_func(#func, user_data)); \
     if (func == nullptr)   \

--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -140,12 +140,12 @@ void ImGui_ImplVulkanH_CreateWindowCommandBuffers(VkPhysicalDevice physical_devi
 
 // Vulkan prototypes for use with custom loaders
 // (see description of IMGUI_IMPL_VULKAN_NO_PROTOTYPES in imgui_impl_vulkan.h
-#ifdef VK_NO_PROTOTYPES
+#if defined(VK_NO_PROTOTYPES) && !defined(VOLK_HEADER_VERSION)
 static bool g_FunctionsLoaded = false;
 #else
 static bool g_FunctionsLoaded = true;
 #endif
-#ifdef VK_NO_PROTOTYPES
+#if defined(VK_NO_PROTOTYPES) && !defined(VOLK_HEADER_VERSION)
 #define IMGUI_VULKAN_FUNC_MAP(IMGUI_VULKAN_FUNC_MAP_MACRO) \
     IMGUI_VULKAN_FUNC_MAP_MACRO(vkAllocateCommandBuffers) \
     IMGUI_VULKAN_FUNC_MAP_MACRO(vkAllocateDescriptorSets) \
@@ -965,7 +965,7 @@ bool    ImGui_ImplVulkan_LoadFunctions(PFN_vkVoidFunction(*loader_func)(const ch
     // You can use the default Vulkan loader using:
     //      ImGui_ImplVulkan_LoadFunctions([](const char* function_name, void*) { return vkGetInstanceProcAddr(your_vk_isntance, function_name); });
     // But this would be equivalent to not setting VK_NO_PROTOTYPES.
-#ifdef VK_NO_PROTOTYPES
+#if defined(VK_NO_PROTOTYPES) && !defined(VOLK_HEADER_VERSION)
 #define IMGUI_VULKAN_FUNC_LOAD(func) \
     func = reinterpret_cast<decltype(func)>(loader_func(#func, user_data)); \
     if (func == nullptr)   \

--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -42,7 +42,11 @@
 #if defined(IMGUI_IMPL_VULKAN_NO_PROTOTYPES) && !defined(VK_NO_PROTOTYPES)
 #define VK_NO_PROTOTYPES
 #endif
+#ifdef RTC
 #include <volk.h>
+#else
+#include <vulkan/vulkan.h>
+#endif
 
 // Initialization data, for ImGui_ImplVulkan_Init()
 // [Please zero-clear before use!]

--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -42,7 +42,7 @@
 #if defined(IMGUI_IMPL_VULKAN_NO_PROTOTYPES) && !defined(VK_NO_PROTOTYPES)
 #define VK_NO_PROTOTYPES
 #endif
-#include "volk.h"
+#include <volk.h>
 
 // Initialization data, for ImGui_ImplVulkan_Init()
 // [Please zero-clear before use!]

--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -42,7 +42,7 @@
 #if defined(IMGUI_IMPL_VULKAN_NO_PROTOTYPES) && !defined(VK_NO_PROTOTYPES)
 #define VK_NO_PROTOTYPES
 #endif
-#include <vulkan/vulkan.h>
+#include "volk.h"
 
 // Initialization data, for ImGui_ImplVulkan_Init()
 // [Please zero-clear before use!]

--- a/imgui_ex.lua
+++ b/imgui_ex.lua
@@ -10,8 +10,6 @@ includedirs {
   ".",
   _3RDPARTY_DIR,
   _3RDPARTY_DIR .. "/glfw/include",
-  _3RDPARTY_DIR .. "/Vulkan-Headers/include",
-  _3RDPARTY_DIR .. "/volk",
 }
 
 files {
@@ -31,6 +29,11 @@ if (_PLATFORM_IOS) then
 end
 
 if (_PLATFORM_LINUX) then
+  includedirs {
+	_3RDPARTY_DIR .. "/Vulkan-Headers/include",
+	_3RDPARTY_DIR .. "/volk",
+  }
+
   files {
     "backends/imgui_impl_vulkan.cpp",
   }
@@ -49,6 +52,11 @@ if (_PLATFORM_MACOS) then
 end
 
 if (_PLATFORM_WINDOWS) then
+  includedirs {
+	_3RDPARTY_DIR .. "/Vulkan-Headers/include",
+	_3RDPARTY_DIR .. "/volk",
+  }
+
   files {
     "backends/imgui_impl_dx11.cpp",
     "backends/imgui_impl_win32.cpp",

--- a/imgui_ex.lua
+++ b/imgui_ex.lua
@@ -10,6 +10,8 @@ includedirs {
   ".",
   _3RDPARTY_DIR,
   _3RDPARTY_DIR .. "/glfw/include",
+  _3RDPARTY_DIR .. "/Vulkan-Headers/include",
+  _3RDPARTY_DIR .. "/volk",
 }
 
 files {
@@ -29,6 +31,9 @@ if (_PLATFORM_IOS) then
 end
 
 if (_PLATFORM_LINUX) then
+  files {
+    "backends/imgui_impl_vulkan.cpp",
+  }
 end
 
 if (_PLATFORM_MACOS) then
@@ -47,6 +52,7 @@ if (_PLATFORM_WINDOWS) then
   files {
     "backends/imgui_impl_dx11.cpp",
     "backends/imgui_impl_win32.cpp",
+    "backends/imgui_impl_vulkan.cpp",
   }
 end
 


### PR DESCRIPTION
Issue(s)
https://devtopia.esri.com/runtime/red-october/issues/1529

Description of change
- Modify `imgui_ex` premake to add vulkan helpers and necessary thirdparty libs (Windows and Linux)
- Modify `imgui_impl_vulkan` to use `volk.h`

Testing
3rdparty: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/821/downstreambuildview/
runtimecore: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/18097/downstreambuildview/
